### PR TITLE
Fix: Sms For Pending payment not being sent

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: E-goi
 Donate link: https://www.e-goi.com
 Tags: SMS, Orders, WooCommerce, Notifications, Alert, sms, order, Subscribe, E-goi, Marketing Automation, egoi, List, SMS Marketing, Marketing, shipping, tracking number, carrier, transportadora, order notification, Multibanco
 Requires at least: 4.7
-Tested up to: 5.3.2
-Stable tag: 1.4.2
+Tested up to: 5.5.1
+Stable tag: 1.4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -130,6 +130,11 @@ Or [WooCommerce PagSeguro](https://wordpress.org/plugins/woocommerce-pagseguro/ 
 3. Encomenda com opção de envio de SMS directo ao cliente
 
 == Changelog ==
+
+= 1.4.3 =
+* Fix: Sms For Pending payment not being sent
+* Tested with wordpress 5.5.1 / Bumped `Tested up to` tag
+* Tested with WooCommerce 4.6.1 / Bumped `WC tested up to` tag
 
 = 1.4.2 =
 * Reminder Messages

--- a/includes/class-smart-marketing-addon-sms-order.php
+++ b/includes/class-smart-marketing-addon-sms-order.php
@@ -169,7 +169,7 @@ class Smart_Marketing_Addon_Sms_Order {
 
 		// CRON and payment reminder
 		$this->loader->add_action('cron_schedules', $plugin_admin, 'smsonw_my_add_every_fifteen_minutes');
-		$this->loader->add_action('egoi_sms_order_event', $plugin_admin, 'smsonw_sms_order_reminder');
+		$this->loader->add_filter('egoi_sms_order_event', $plugin_admin, 'smsonw_sms_order_reminder');
 
 		// Box send SMS in admin order page
 		$this->loader->add_action('add_meta_boxes', $plugin_admin, 'smsonw_order_add_sms_meta_box');

--- a/smart-marketing-addon-sms-order.php
+++ b/smart-marketing-addon-sms-order.php
@@ -16,7 +16,7 @@
  * Plugin Name:       SMS Orders Alert/Notifications for WooCommerce
  * Plugin URI:        https://wordpress.org/plugins/sms-orders-alertnotifications-for-woocommerce/
  * Description:       Send SMS notifications to your buyers and admins for each change to the order status in your WooCommerce store. Increase your conversions and better communicate with your customers.
- * Version:           1.4.2
+ * Version:           1.4.3
  * Author:            E-goi
  * Author URI:        https://www.e-goi.com
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@
  * Text Domain:       smart-marketing-addon-sms-order
  * Domain Path:       /languages
  * WC requires at least: 3.2
- * WC tested up to: 4.0.0
+ * WC tested up to: 4.6.1
  */
 
 // If this file is called directly, abort.
@@ -78,7 +78,7 @@ function smsonw_child_plugin_notice(){
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'PLUGIN_NAME_VERSION', '1.4.2' );
+define( 'PLUGIN_NAME_VERSION', '1.4.3' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
Sms messages not beeing sent with payment information when status was Pending Payment
* Fix: Sms For Pending payment not being sent
* Tested with wordpress 5.5.1 / Bumped `Tested up to` tag
* Tested with WooCommerce 4.6.1 / Bumped `WC tested up to` tag